### PR TITLE
fix: return SEVERITY_FATAL on missing environment context

### DIFF
--- a/function/fn.py
+++ b/function/fn.py
@@ -520,11 +520,15 @@ class Runner(grpcv1.FunctionRunnerService):
             await self.mutate_resource(res=res),
         )
 
-    async def read_environment(self, req: fnv1.RunFunctionRequest) -> None:
+    async def read_environment(
+        self, req: fnv1.RunFunctionRequest, rsp: fnv1.RunFunctionResponse
+    ) -> bool:
         """Read Context and the Function input.
 
         This context is shared by all resources of a composition, so we should never alter
         self.environment from resource annotations.
+
+        Returns True if the environment was read successfully, False otherwise.
         """
         self.input = resource.struct_to_dict(req.input).get("spec", {})
         context = self.input.get(c.INPUT_CONTEXT, c.CONTEXT_KEY_ENVIRONMENT)
@@ -538,7 +542,8 @@ class Runner(grpcv1.FunctionRunnerService):
         except (KeyError, ValueError) as exc:
             msg = f"Failed to read context '{context}': {exc!r}"
             self.log.error(msg)
-            raise Exception(msg) from exc
+            response.fatal(rsp, msg)
+            return False
 
         self.environment = resource.struct_to_dict(request_context)
         self.environment.update(self.input.get(c.INPUT_VALUES, {}))
@@ -559,6 +564,7 @@ class Runner(grpcv1.FunctionRunnerService):
             c.INPUT_KEBAB_CASE_LABELS_AND_TAGS,
             default=self.kebab_cased_labels_and_tags,
         )
+        return True
 
     async def replicate_labels(self, res: Resource) -> None:
         """Replicate labels from the resource's metadata to a given resource field."""
@@ -600,9 +606,11 @@ class Runner(grpcv1.FunctionRunnerService):
         else:
             rsp = response.to(req)
         self.log.debug("Invoked function-naming-convention")
-        try:
-            await self.read_environment(req)
 
+        if not await self.read_environment(req, rsp):
+            return rsp
+
+        try:
             # Populate which Environment variables should be mapped to labels
             self.ENV_TO_LABEL = self.input.get(c.INPUT_ENV_TO_LABEL, [])
             async with asyncio.TaskGroup() as tg:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ validate-bump = false            # Allow going from 0.0.0.dev0+x to 0.0.0.dev0+y
 [tool.hatch.envs.default]
 type = "virtual"
 path = ".venv-default"
-dependencies = ["ipython==9.10.0"]
+dependencies = ["ipython==9.15.0"]
 
 [tool.hatch.envs.default.scripts]
 development = "python function/main.py --insecure --debug"
@@ -54,7 +54,7 @@ development = "python function/main.py --insecure --debug"
 type = "virtual"
 detached = true
 path = ".venv-lint"
-dependencies = ["ruff==0.15.19"]
+dependencies = ["ruff==0.15.20"]
 
 [tool.hatch.envs.lint.scripts]
 check = "ruff check function tests --fix && ruff format --diff function tests"

--- a/tests/test_fn.py
+++ b/tests/test_fn.py
@@ -2161,6 +2161,67 @@ TESTCASES = [
             context=CONTEXT,
         ),
     ),
+    TestCase(
+        reason="The function should return SEVERITY_FATAL when the context is missing.",
+        req=fnv1.RunFunctionRequest(
+            context=CONTEXT,
+            desired=fnv1.State(
+                resources={
+                    "resource-a": fnv1.Resource(
+                        resource=resource.dict_to_struct(
+                            {
+                                "apiVersion": "example.crossplane.io/v1alpha1",
+                                "kind": "XTest",
+                                "metadata": {
+                                    "name": "foo",
+                                },
+                                "spec": {},
+                            }
+                        )
+                    ),
+                }
+            ),
+            input=structpb.Struct(
+                fields={
+                    "spec": structpb.Value(
+                        struct_value=structpb.Struct(
+                            fields={
+                                c.INPUT_CONTEXT: structpb.Value(
+                                    string_value="non-existing-context"
+                                ),
+                            }
+                        )
+                    )
+                }
+            ),
+        ),
+        want=fnv1.RunFunctionResponse(
+            meta=fnv1.ResponseMeta(ttl=durationpb.Duration(seconds=60)),
+            desired=fnv1.State(
+                resources={
+                    "resource-a": fnv1.Resource(
+                        resource=resource.dict_to_struct(
+                            {
+                                "apiVersion": "example.crossplane.io/v1alpha1",
+                                "kind": "XTest",
+                                "metadata": {
+                                    "name": "foo",
+                                },
+                                "spec": {},
+                            }
+                        )
+                    ),
+                }
+            ),
+            results=[
+                fnv1.Result(
+                    severity=fnv1.SEVERITY_FATAL,
+                    message="Failed to read context 'non-existing-context': ValueError('Value not set')",
+                ),
+            ],
+            context=CONTEXT,
+        ),
+    ),
 ]
 
 TESTEXCEPTIONS_NAME_TOO_LONG = [
@@ -2451,61 +2512,6 @@ TESTEXCEPTIONS = [
                                         f"{PREFIX}account": "bar",
                                         f"{PREFIX}ls-domain": "core",
                                     },
-                                    "name": "foo",
-                                },
-                                "spec": {},
-                            }
-                        )
-                    ),
-                }
-            ),
-            context=CONTEXT,
-        ),
-    ),
-    TestCase(
-        reason="The function should abort when the context is missing.",
-        req=fnv1.RunFunctionRequest(
-            context=CONTEXT,
-            desired=fnv1.State(
-                resources={
-                    "resource-a": fnv1.Resource(
-                        resource=resource.dict_to_struct(
-                            {
-                                "apiVersion": "example.crossplane.io/v1alpha1",
-                                "kind": "XTest",
-                                "metadata": {
-                                    "name": "foo",
-                                },
-                                "spec": {},
-                            }
-                        )
-                    ),
-                }
-            ),
-            input=structpb.Struct(
-                fields={
-                    "spec": structpb.Value(
-                        struct_value=structpb.Struct(
-                            fields={
-                                c.INPUT_CONTEXT: structpb.Value(
-                                    string_value="non-existing-context"
-                                ),
-                            }
-                        )
-                    )
-                }
-            ),
-        ),
-        want=fnv1.RunFunctionResponse(
-            meta=fnv1.ResponseMeta(ttl=durationpb.Duration(seconds=60)),
-            desired=fnv1.State(
-                resources={
-                    "resource-a": fnv1.Resource(
-                        resource=resource.dict_to_struct(
-                            {
-                                "apiVersion": "example.crossplane.io/v1alpha1",
-                                "kind": "XTest",
-                                "metadata": {
                                     "name": "foo",
                                 },
                                 "spec": {},


### PR DESCRIPTION
## Summary

- `read_environment` now returns a `SEVERITY_FATAL` result via `response.fatal()` instead of raising an exception when the context key is not found.
- `RunFunction` early-returns the response with the fatal result, giving Crossplane a
proper status condition to surface on the XR.
- Resource mutation errors (name too long, missing name items) still use `context.abort` as before.

Fixes: #60 

## Test plan

- [x] Existing tests pass — missing-context case moved from exception tests to standard
test cases with expected `SEVERITY_FATAL` result.
- [x] Name-too-long and missing-name-items exceptions still trigger `context.abort`.